### PR TITLE
Update to Portworx 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,11 @@ For architectural details, best practices, step-by-step instructions, and custom
 To post feedback, submit feature ideas, or report bugs, use the **Issues** section of this GitHub repo. If you'd like to submit code for this Quick Start, please review the [AWS Quick Start Contributor's Kit](https://aws-quickstart.github.io/).
 
 This Quick Start was built in collaboration with [Portworx, Inc.](https://portworx.com), an AWS Partner Network (APN) Partner.
+
+
+### TODO / Currently Unsupported
+
+- Allow custom Portworx configuration for oci-monitor
+- Allow CSI Installation On/Off configuration
+- Add DR Sync Configurable (Domain)
+- Build in Portworx Monitoring to initial deployment

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ This Quick Start was built in collaboration with [Portworx, Inc.](https://portwo
 ### TODO / Limitations
 
 - Allow custom Portworx configuration for oci-monitor
-	- Currently only a subset of parameters are used (Example, external ETCD currently not configurable from QuickStart)
-- Add DR Sync Configurable (Domain)
-- Allow CSI Installation On/Off configuration
-	- (users can still update to use CSI with `kubectl` from bastion host)
-- Build in Portworx Monitoring to initial deployment
-	- (users can still install monitoring with `kubectl` from bastion host)
+	- Currently only a subset of parameters are used and limit configuration. 
+	- Note, some of these options can be changes using `kubectl` on the bastion host.
+	- Examples of currently unsupported options **during stack creation**:
+		- External ETCD currently not configurable.
+		- Synchronouse DR. Which would need to add `cluster_domain`.
+		- Use CSI or not. (Does not by default)

--- a/README.md
+++ b/README.md
@@ -23,9 +23,12 @@ To post feedback, submit feature ideas, or report bugs, use the **Issues** secti
 This Quick Start was built in collaboration with [Portworx, Inc.](https://portworx.com), an AWS Partner Network (APN) Partner.
 
 
-### TODO / Currently Unsupported
+### TODO / Limitations
 
 - Allow custom Portworx configuration for oci-monitor
-- Allow CSI Installation On/Off configuration
+	- Currently only a subset of parameters are used (Example, external ETCD currently not configurable from QuickStart)
 - Add DR Sync Configurable (Domain)
+- Allow CSI Installation On/Off configuration
+	- (users can still update to use CSI with `kubectl` from bastion host)
 - Build in Portworx Monitoring to initial deployment
+	- (users can still install monitoring with `kubectl` from bastion host)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,11 @@
+## How to use examples
+
+Only use these stacks **AFTER** you deploy Portworx QuickStart
+
+Step 1 - Click create new stack from CloudFormation Console.
+Step 2 - Fill in Stack Name
+Step 3 - Fill in `KubeManifestConfig` with value of `KubeManifestLambdaArn` from the outputs in the stack with description `Deploys Lambda functions required for the AWS EKS Quick Start`.
+Step 4 - Fill in `The s3 path to the KubeConfig.` with value of `KubeConfigPath` in the ouputs of your main Portworx Stack with the description that starts with `Deploys Portworx Enterprise`.
+Step 5 - Fill in or accept defaults of any other parameters and click `Next` ,`Next`, and `Create Stack`!
+
+After deploying the example, use the Bastion host to use `kubectl` and see your new resources deployed.

--- a/examples/pwx-monitoring/pwx-monitoring-stack.yaml
+++ b/examples/pwx-monitoring/pwx-monitoring-stack.yaml
@@ -1,0 +1,559 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Deploys Prometheus and connect Portworx to Prometheus for Metrics
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: KubeManifestConfig
+      Parameters:
+      - KubeManifestLambdaArn
+      - KubeConfigPath
+      - KubeConfigKmsContext
+    - Label:
+        default: Portworx Database Config
+      Parameters:
+      - ConfigMapReloadImage
+      - PrometheusImage
+      - TrueParam
+    ParameterLabels:
+      KubeManifestLambdaArn:
+        default: The KubeManifest Lambda Arn used to interact with the EKS Cluster
+      KubeConfigPath:
+        default: The s3 path to the KubeConfig.
+      KubeConfigKmsContext:
+        default: The KMS context used to access the KubeConfig
+      ConfigMapReloadImage:
+        default:  Configmap-reload image
+      PrometheusImage:
+        default: Prometheus image used below.
+      TrueParam:
+        default: true value
+Parameters:
+  KubeManifestLambdaArn:
+    Description: The AWS kubectl Lamnda Arn used to interact with the EKS Cluster
+    Type: String
+  KubeConfigPath:
+    Description: The s3 path to the KubeConfig.
+    Type: String
+  KubeConfigKmsContext:
+    Description: The KMS context used to access the KubeConfig.
+    Type: String
+    Default: "EKSQuickStart"
+  ConfigMapReloadImage:
+    Type: String
+    Default: "quay.io/coreos/configmap-reload:v0.0.1" 
+    Description: Configmap-reload image
+  PrometheusImage:
+    Type: String
+    Default: "quay.io/coreos/prometheus-operator:v0.29.0"
+    Description: Prometheus image used below.
+  TrueParam:
+    Type: String
+    Default: "true" 
+    Description: true that is not a bool
+Resources:
+  PromClusterRoleBinding:
+    Type: "Custom::KubeManifest"
+    Version: '1.0'
+    Properties:
+      # The lambda function that executes the manifest against the cluster. This is created in one of the parent stacks
+      ServiceToken: !Ref KubeManifestLambdaArn
+      # S3 path to the encrypted config file eg. s3://my-bucket/kube/config.encrypted
+      KubeConfigPath: !Ref KubeConfigPath
+      # context for KMS to use when decrypting the file
+      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      # Kubernetes manifest
+      Manifest:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: prometheus-operator
+          namespace: kube-system
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: prometheus-operator
+        subjects:
+          - kind: ServiceAccount
+            name: prometheus-operator
+            namespace: kube-system
+  PromClusterRole:
+    Type: "Custom::KubeManifest"
+    Version: '1.0'
+    Properties:
+      # The lambda function that executes the manifest against the cluster. This is created in one of the parent stacks
+      ServiceToken: !Ref KubeManifestLambdaArn
+      # S3 path to the encrypted config file eg. s3://my-bucket/kube/config.encrypted
+      KubeConfigPath: !Ref KubeConfigPath
+      # context for KMS to use when decrypting the file
+      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      # Kubernetes manifest
+      Manifest:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          name: prometheus-operator
+          namespace: kube-system
+        rules:
+          - apiGroups:
+              - extensions
+            resources:
+              - thirdpartyresources
+            verbs: ["*"]
+          - apiGroups:
+              - apiextensions.k8s.io
+            resources:
+              - customresourcedefinitions
+            verbs: ["*"]
+          - apiGroups:
+              - monitoring.coreos.com
+            resources:
+              - alertmanagers
+              - prometheuses
+              - prometheuses/finalizers
+              - servicemonitors
+              - prometheusrules
+            verbs: ["*"]
+          - apiGroups:
+              - apps
+            resources:
+              - statefulsets
+            verbs: ["*"]
+          - apiGroups: [""]
+            resources:
+              - configmaps
+              - secrets
+            verbs: ["*"]
+          - apiGroups: [""]
+            resources:
+              - pods
+            verbs: ["list", "delete"]
+          - apiGroups: [""]
+            resources:
+              - services
+              - endpoints
+            verbs: ["get", "create", "update"]
+          - apiGroups: [""]
+            resources:
+              - nodes
+            verbs: ["list", "watch"]
+          - apiGroups: [""]
+            resources:
+              - namespaces
+            verbs: ["list", "watch"]
+  PromServiceAccount:
+    Type: "Custom::KubeManifest"
+    Version: '1.0'
+    Properties:
+      # The lambda function that executes the manifest against the cluster. This is created in one of the parent stacks
+      ServiceToken: !Ref KubeManifestLambdaArn
+      # S3 path to the encrypted config file eg. s3://my-bucket/kube/config.encrypted
+      KubeConfigPath: !Ref KubeConfigPath
+      # context for KMS to use when decrypting the file
+      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      # Kubernetes manifest
+      Manifest:
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: prometheus-operator
+          namespace: kube-system
+  PromOperatorDeployment:
+    Type: "Custom::KubeManifest"
+    Version: '1.0'
+    Properties:
+      # The lambda function that executes the manifest against the cluster. This is created in one of the parent stacks
+      ServiceToken: !Ref KubeManifestLambdaArn
+      # S3 path to the encrypted config file eg. s3://my-bucket/kube/config.encrypted
+      KubeConfigPath: !Ref KubeConfigPath
+      # context for KMS to use when decrypting the file
+      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      #true
+      TrueParam: !Ref TrueParam
+      ConfigMapReloadImage: !Ref ConfigMapReloadImage
+      PrometheusImage: !Ref PrometheusImage
+      # Kubernetes manifest
+      Manifest: !Sub |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          labels:
+            k8s-app: prometheus-operator
+          name: prometheus-operator
+          namespace: kube-system
+        spec:
+          selector:
+            matchLabels:
+              k8s-app: prometheus-operator
+          replicas: 1
+          template:
+            metadata:
+              labels:
+                k8s-app: prometheus-operator
+            spec:
+              containers:
+                - args:
+                    - --kubelet-service=kube-system/kubelet
+                    - --config-reloader-image=${ConfigMapReloadImage}
+                  image: ${PrometheusImage}
+                  name: prometheus-operator
+                  ports:
+                    - containerPort: 8080
+                      name: http
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 100Mi
+                    requests:
+                      cpu: 100m
+                      memory: 50Mi
+              securityContext:
+                runAsNonRoot: ${TrueParam}
+                runAsUser: 65534
+              serviceAccountName: prometheus-operator
+  PXServiceMonitor:
+    DependsOn: PromOperatorDeployment
+    Type: "Custom::KubeManifest"
+    Version: '1.0'
+    Properties:
+      # The lambda function that executes the manifest against the cluster. This is created in one of the parent stacks
+      ServiceToken: !Ref KubeManifestLambdaArn
+      # S3 path to the encrypted config file eg. s3://my-bucket/kube/config.encrypted
+      KubeConfigPath: !Ref KubeConfigPath
+      # context for KMS to use when decrypting the file
+      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      # Kubernetes manifest
+      Manifest: !Sub |
+        apiVersion: monitoring.coreos.com/v1
+        kind: ServiceMonitor
+        metadata:
+          namespace: kube-system
+          name: portworx-prometheus-sm
+          labels:
+            name: portworx-prometheus-sm
+        spec:
+          selector:
+            matchLabels:
+              name: portworx
+          namespaceSelector:
+            any: true
+          endpoints:
+            - port: px-api
+              targetPort: 9001
+            - port: px-kvdb
+              targetPort: 9019
+  PXAlertManager:
+    DependsOn: PromOperatorDeployment
+    Type: "Custom::KubeManifest"
+    Version: '1.0'
+    Properties:
+      # The lambda function that executes the manifest against the cluster. This is created in one of the parent stacks
+      ServiceToken: !Ref KubeManifestLambdaArn
+      # S3 path to the encrypted config file eg. s3://my-bucket/kube/config.encrypted
+      KubeConfigPath: !Ref KubeConfigPath
+      # context for KMS to use when decrypting the file
+      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      # Kubernetes manifest
+      Manifest:
+        apiVersion: monitoring.coreos.com/v1
+        kind: Alertmanager
+        metadata:
+          name: portworx #This name is important since the Alertmanager pods wont start unless a secret named alertmanager-${ALERTMANAGER_NAME} is created. in this case if would expect alertmanager-portworx secret in the kube-system namespace
+          namespace: kube-system
+          labels:
+            alertmanager: portworx
+        spec:
+          replicas: 3
+  PXAlertManagerService:
+    Type: "Custom::KubeManifest"
+    Version: '1.0'
+    Properties:
+      # The lambda function that executes the manifest against the cluster. This is created in one of the parent stacks
+      ServiceToken: !Ref KubeManifestLambdaArn
+      # S3 path to the encrypted config file eg. s3://my-bucket/kube/config.encrypted
+      KubeConfigPath: !Ref KubeConfigPath
+      # context for KMS to use when decrypting the file
+      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      # Kubernetes manifest
+      Manifest:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: alertmanager-portworx
+          namespace: kube-system
+        spec:
+          type: NodePort
+          ports:
+            - name: web
+              port: 9093
+              protocol: TCP
+              targetPort: 9093
+          selector:
+            alertmanager: portworx
+  PXPrometheusRule:
+    Type: "Custom::KubeManifest"
+    Version: '1.0'
+    Properties:
+      # The lambda function that executes the manifest against the cluster. This is created in one of the parent stacks
+      ServiceToken: !Ref KubeManifestLambdaArn
+      # S3 path to the encrypted config file eg. s3://my-bucket/kube/config.encrypted
+      KubeConfigPath: !Ref KubeConfigPath
+      # context for KMS to use when decrypting the file
+      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      # Kubernetes manifest
+      Manifest: !Sub |
+        apiVersion: monitoring.coreos.com/v1
+        kind: PrometheusRule
+        metadata:
+          labels:
+            prometheus: portworx
+            role: prometheus-portworx-rulefiles
+          name: prometheus-portworx-rules-portworx.rules.yaml
+          namespace: kube-system
+        spec:
+          groups:
+          - name: portworx.rules
+            rules:
+            - alert: PortworxVolumeUsageCritical
+              annotations:
+                description: Portworx volume {{$labels.volumeid}} on {{$labels.host}} is over 80% used for
+                  more than 10 minutes.
+                summary: Portworx volume capacity is at {{$value}}% used.
+              expr: 100 * (px_volume_usage_bytes / px_volume_capacity_bytes) > 80
+              for: 5m
+              labels:
+                issue: Portworx volume {{$labels.volumeid}} usage on {{$labels.host}} is high.
+                severity: critical
+            - alert: PortworxVolumeUsage
+              annotations:
+                description: Portworx volume {{$labels.volumeid}} on {{$labels.host}} is over 70% used for
+                  more than 10 minutes.
+                summary: Portworx volume {{$labels.volumeid}} on {{$labels.host}} is at {{$value}}% used.
+              expr: 100 * (px_volume_usage_bytes / px_volume_capacity_bytes) > 70
+              for: 5m
+              labels:
+                issue: Portworx volume {{$labels.volumeid}} usage on {{$labels.host}} is critical.
+                severity: warning
+            - alert: PortworxVolumeWillFill
+              annotations:
+                description: Disk volume {{$labels.volumeid}} on {{$labels.host}} is over 70% full and has
+                  been predicted to fill within 2 weeks for more than 10 minutes.
+                summary: Portworx volume {{$labels.volumeid}} on {{$labels.host}} is over 70% full and is
+                  predicted to fill within 2 weeks.
+              expr: (px_volume_usage_bytes / px_volume_capacity_bytes) > 0.7 and predict_linear(px_cluster_disk_available_bytes[1h],
+                14 * 86400) < 0
+              for: 10m
+              labels:
+                issue: Disk volume {{$labels.volumeid}} on {{$labels.host}} is predicted to fill within
+                  2 weeks.
+                severity: warning
+            - alert: PortworxStorageUsageCritical
+              annotations:
+                description: Portworx storage {{$labels.volumeid}} on {{$labels.host}} is over 80% used
+                  for more than 10 minutes.
+                summary: Portworx storage capacity is at {{$value}}% used.
+              expr: 100 * (1 - px_cluster_disk_utilized_bytes / px_cluster_disk_total_bytes)
+                < 20
+              for: 5m
+              labels:
+                issue: Portworx storage {{$labels.volumeid}} usage on {{$labels.host}} is high.
+                severity: critical
+            - alert: PortworxStorageUsage
+              annotations:
+                description: Portworx storage {{$labels.volumeid}} on {{$labels.host}} is over 70% used
+                  for more than 10 minutes.
+                summary: Portworx storage {{$labels.volumeid}} on {{$labels.host}} is at {{$value}}% used.
+              expr: 100 * (1 - (px_cluster_disk_utilized_bytes / px_cluster_disk_total_bytes))
+                < 30
+              for: 5m
+              labels:
+                issue: Portworx storage {{$labels.volumeid}} usage on {{$labels.host}} is critical.
+                severity: warning
+            - alert: PortworxStorageWillFill
+              annotations:
+                description: Portworx storage {{$labels.volumeid}} on {{$labels.host}} is over 70% full
+                  and has been predicted to fill within 2 weeks for more than 10 minutes.
+                summary: Portworx storage {{$labels.volumeid}} on {{$labels.host}} is over 70% full and
+                  is predicted to fill within 2 weeks.
+              expr: (100 * (1 - (px_cluster_disk_utilized_bytes / px_cluster_disk_total_bytes)))
+                < 30 and predict_linear(px_cluster_disk_available_bytes[1h], 14 * 86400) <
+                0
+              for: 10m
+              labels:
+                issue: Portworx storage {{$labels.volumeid}} on {{$labels.host}} is predicted to fill within
+                  2 weeks.
+                severity: warning
+            - alert: PortworxStorageNodeDown
+              annotations:
+                description: Portworx Storage Node has been offline for more than 5 minutes.
+                summary: Portworx Storage Node is Offline.
+              expr: max(px_cluster_status_nodes_storage_down) > 0
+              for: 5m
+              labels:
+                issue: Portworx Storage Node is Offline.
+                severity: critical
+            - alert: PortworxQuorumUnhealthy
+              annotations:
+                description: Portworx cluster Quorum Unhealthy for more than 5 minutes.
+                summary: Portworx Quorum Unhealthy.
+              expr: max(px_cluster_status_cluster_quorum) > 1
+              for: 5m
+              labels:
+                issue: Portworx Quorum Unhealthy.
+                severity: critical
+            - alert: PortworxMemberDown
+              annotations:
+                description: Portworx cluster member(s) has(have) been down for more than
+                  5 minutes.
+                summary: Portworx cluster member(s) is(are) down.
+              expr: (max(px_cluster_status_cluster_size) - count(px_cluster_status_cluster_size))
+                > 0
+              for: 5m
+              labels:
+                issue: Portworx cluster member(s) is(are) down.
+                severity: critical
+  PXPrometheusServiceAccount:
+    Type: "Custom::KubeManifest"
+    Version: '1.0'
+    Properties:
+      # The lambda function that executes the manifest against the cluster. This is created in one of the parent stacks
+      ServiceToken: !Ref KubeManifestLambdaArn
+      # S3 path to the encrypted config file eg. s3://my-bucket/kube/config.encrypted
+      KubeConfigPath: !Ref KubeConfigPath
+      # context for KMS to use when decrypting the file
+      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      # Kubernetes manifest
+      Manifest:
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: prometheus
+          namespace: kube-system
+  PXPrometheusClusterRole:
+    Type: "Custom::KubeManifest"
+    Version: '1.0'
+    Properties:
+      # The lambda function that executes the manifest against the cluster. This is created in one of the parent stacks
+      ServiceToken: !Ref KubeManifestLambdaArn
+      # S3 path to the encrypted config file eg. s3://my-bucket/kube/config.encrypted
+      KubeConfigPath: !Ref KubeConfigPath
+      # context for KMS to use when decrypting the file
+      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      # Kubernetes manifest
+      Manifest:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          name: prometheus
+          namespace: kube-system
+        rules:
+          - apiGroups: [""]
+            resources:
+              - nodes
+              - services
+              - endpoints
+              - pods
+            verbs: ["get", "list", "watch"]
+          - apiGroups: [""]
+            resources:
+              - configmaps
+            verbs: ["get"]
+          - nonResourceURLs: ["/metrics", "/federate"]
+            verbs: ["get"]
+  PXPrometheusClusterRoleBinding:
+    Type: "Custom::KubeManifest"
+    Version: '1.0'
+    Properties:
+      # The lambda function that executes the manifest against the cluster. This is created in one of the parent stacks
+      ServiceToken: !Ref KubeManifestLambdaArn
+      # S3 path to the encrypted config file eg. s3://my-bucket/kube/config.encrypted
+      KubeConfigPath: !Ref KubeConfigPath
+      # context for KMS to use when decrypting the file
+      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      # Kubernetes manifest
+      Manifest:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: prometheus
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: prometheus
+        subjects:
+          - kind: ServiceAccount
+            name: prometheus
+            namespace: kube-system
+  PXPrometheus:
+    DependsOn: PromOperatorDeployment
+    Type: "Custom::KubeManifest"
+    Version: '1.0'
+    Properties:
+      # The lambda function that executes the manifest against the cluster. This is created in one of the parent stacks
+      ServiceToken: !Ref KubeManifestLambdaArn
+      # S3 path to the encrypted config file eg. s3://my-bucket/kube/config.encrypted
+      KubeConfigPath: !Ref KubeConfigPath
+      # context for KMS to use when decrypting the file
+      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      # Kubernetes manifest
+      Manifest:
+        apiVersion: monitoring.coreos.com/v1
+        kind: Prometheus
+        metadata:
+          name: prometheus
+          namespace: kube-system
+        spec:
+          replicas: 2
+          logLevel: debug
+          serviceAccountName: prometheus
+          alerting:
+            alertmanagers:
+              - namespace: kube-system
+                name: alertmanager-portworx
+                port: web
+          serviceMonitorSelector:
+            matchLabels:
+              name: portworx-prometheus-sm
+            namespaceSelector:
+              matchNames:
+                - kube-system
+            resources:
+              requests:
+                memory: 400Mi
+          ruleSelector:
+            matchLabels:
+              role: prometheus-portworx-rulefiles
+              prometheus: portworx
+            namespaceSelector:
+              matchNames:
+                - kube-system
+  PXPrometheusService:
+    DependsOn: PromOperatorDeployment
+    Type: "Custom::KubeManifest"
+    Version: '1.0'
+    Properties:
+      # The lambda function that executes the manifest against the cluster. This is created in one of the parent stacks
+      ServiceToken: !Ref KubeManifestLambdaArn
+      # S3 path to the encrypted config file eg. s3://my-bucket/kube/config.encrypted
+      KubeConfigPath: !Ref KubeConfigPath
+      # context for KMS to use when decrypting the file
+      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      # Kubernetes manifest
+      Manifest:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: prometheus
+          namespace: kube-system
+        spec:
+          type: LoadBalancer
+          ports:
+            - name: web
+              port: 9090
+              protocol: TCP
+              targetPort: 9090
+          selector:
+            prometheus: prometheus
+Outputs:
+  PromOperatorDeploymentUid:
+    Value: !GetAtt PromOperatorDeployment.uid

--- a/templates/portworx-master-existing-vpc.template.yaml
+++ b/templates/portworx-master-existing-vpc.template.yaml
@@ -29,7 +29,6 @@ Metadata:
     - Label:
         default: Portworx configuration
       Parameters:
-      - PXKubernetesVersion
       - PortworxVersion
       - LightHouseVersion
       - VolumeTemplateString
@@ -70,8 +69,6 @@ Metadata:
         default: Additional EKS admin ARNs
       KubernetesVersion:
         default: Kubernetes version
-      PXKubernetesVersion:
-        default: Portworx version tag
       PortworxVersion:
         default: Version of Portworx X.Y.Z
       LightHouseVersion:
@@ -237,21 +234,16 @@ if left blank, a bucket will be created.'
     Description: The ID of the private subnet 3 in Availability Zone 3 (e.g., subnet-a0246dcd).
     Type: "AWS::EC2::Subnet::Id"
   KubernetesVersion:
-    Description: The Kubernetes version  of the Amazon EKS cluster.
+    Description: The Kubernetes version  of the Amazon EKS cluster. (https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html)
     Type: String
-    AllowedValues: [ "1.11", "1.10" ]
-    Default: "1.11"
-  PXKubernetesVersion:
-    Type: String
-    Default: "v1.11.0"
-    Description:  The tag for the Portworx container image version.
+    Default: "1.14.7"
   PortworxVersion:
     Type: String
-    Default: "2.0.1"
+    Default: "2.2.0"
     Description: The version of Portworx that is deployed by this Quick Start.
   LightHouseVersion:
     Type: String
-    Default: "2.0.1"
+    Default: "2.0.5"
     Description: The version of the Portworx Lighthouse UI.
   VolumeTemplateString:
     Type: String
@@ -295,11 +287,11 @@ Resources:
         KubeManifestLambdaArn: !GetAtt EKSStack.Outputs.KubeManifestLambdaArn
         PortworxClusterName: !Join [ "-", [ !GetAtt EKSStack.Outputs.EKSClusterName, "portworx-cluster" ] ]
         NodeGroupIAMRole: !GetAtt EKSStack.Outputs.NodeGroupIAMRole
-        PXKubernetesVersion: !Ref PXKubernetesVersion
         PortworxVersion: !Ref PortworxVersion
         LightHouseVersion: !Ref LightHouseVersion
         VolumeTemplateString: !Ref VolumeTemplateString
         MetadataTemplateString: !Ref MetadataTemplateString
+        KubernetesVersion: !Ref PXKubernetesVersion
 Outputs:
   KubeConfigPath:
     Value: !GetAtt EKSStack.Outputs.KubeConfigPath

--- a/templates/portworx-master-existing-vpc.template.yaml
+++ b/templates/portworx-master-existing-vpc.template.yaml
@@ -234,9 +234,9 @@ if left blank, a bucket will be created.'
     Description: The ID of the private subnet 3 in Availability Zone 3 (e.g., subnet-a0246dcd).
     Type: "AWS::EC2::Subnet::Id"
   KubernetesVersion:
-    Description: The Kubernetes version  of the Amazon EKS cluster. (https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html)
+    Description: The Kubernetes version  of the Amazon EKS cluster. (https://github.com/aws-quickstart/quickstart-amazon-eks/blob/master/templates/amazon-eks.template.yaml#L142)
     Type: String
-    Default: "1.14.7"
+    Default: "1.13.0"
   PortworxVersion:
     Type: String
     Default: "2.2.0"

--- a/templates/portworx-master-existing-vpc.template.yaml
+++ b/templates/portworx-master-existing-vpc.template.yaml
@@ -33,6 +33,7 @@ Metadata:
       - PortworxVersion
       - LightHouseVersion
       - VolumeTemplateString
+      - MetadataTemplateString
     - Label:
         default: AWS Quick Start configuration
       Parameters:
@@ -77,6 +78,8 @@ Metadata:
         default: Version of Lighthouse X.Y.Z
       VolumeTemplateString:
         default: Template string for partitioning
+      MetadataTemplateString:
+        default: Template string for metadata
       VPCID:
         default: VPC ID
 Parameters:
@@ -254,6 +257,10 @@ if left blank, a bucket will be created.'
     Type: String
     Default: "type=gp2,size=100"
     Description: The template string used for partitioning. For more information, see https://docs.portworx.com/cloud-references/auto-disk-provisioning/aws/.
+  MetadataTemplateString:
+    Type: String
+    Default: "type=gp2,size=100"
+    Description: The template string used for metadata.
 Resources:
   EKSStack:
     Type: AWS::CloudFormation::Stack
@@ -292,6 +299,7 @@ Resources:
         PortworxVersion: !Ref PortworxVersion
         LightHouseVersion: !Ref LightHouseVersion
         VolumeTemplateString: !Ref VolumeTemplateString
+        MetadataTemplateString: !Ref MetadataTemplateString
 Outputs:
   KubeConfigPath:
     Value: !GetAtt EKSStack.Outputs.KubeConfigPath

--- a/templates/portworx-master-existing-vpc.template.yaml
+++ b/templates/portworx-master-existing-vpc.template.yaml
@@ -236,7 +236,7 @@ if left blank, a bucket will be created.'
   KubernetesVersion:
     Description: The Kubernetes version  of the Amazon EKS cluster. (https://github.com/aws-quickstart/quickstart-amazon-eks/blob/master/templates/amazon-eks.template.yaml#L142)
     Type: String
-    Default: "1.13.0"
+    Default: "1.13"
   PortworxVersion:
     Type: String
     Default: "2.2.0"

--- a/templates/portworx-master-existing-vpc.template.yaml
+++ b/templates/portworx-master-existing-vpc.template.yaml
@@ -291,7 +291,7 @@ Resources:
         LightHouseVersion: !Ref LightHouseVersion
         VolumeTemplateString: !Ref VolumeTemplateString
         MetadataTemplateString: !Ref MetadataTemplateString
-        KubernetesVersion: !Ref PXKubernetesVersion
+        PXKubernetesVersion: !Ref KubernetesVersion
 Outputs:
   KubeConfigPath:
     Value: !GetAtt EKSStack.Outputs.KubeConfigPath

--- a/templates/portworx-master.template.yaml
+++ b/templates/portworx-master.template.yaml
@@ -35,6 +35,7 @@ Metadata:
       - PortworxVersion
       - LightHouseVersion
       - VolumeTemplateString
+      - MetadataTemplateString
     - Label:
         default: AWS Quick Start configuration
       Parameters:
@@ -85,6 +86,8 @@ Metadata:
         default: Version of Lighthouse X.Y.Z
       VolumeTemplateString:
         default: Template string for partitioning
+      MetadataTemplateString:
+        default: Template string for metadata
 Parameters:
   AvailabilityZones:
     Description: The list of Availability Zones to use for the subnets in the VPC. Three
@@ -290,6 +293,10 @@ Parameters:
     Type: String
     Default: "type=gp2,size=100"
     Description: The template string used for partitioning. For more information, see https://docs.portworx.com/cloud-references/auto-disk-provisioning/aws/.
+  MetadataTemplateString:
+    Type: String
+    Default: "type=gp2,size=100"
+    Description: The template string used for metadata.
 Resources:
   VPCStack:
     Type: AWS::CloudFormation::Stack
@@ -347,6 +354,7 @@ Resources:
         PortworxVersion: !Ref PortworxVersion
         LightHouseVersion: !Ref LightHouseVersion
         VolumeTemplateString: !Ref VolumeTemplateString
+        MetadataTemplateString: !Ref MetadataTemplateString
 Outputs:
   KubeConfigPath:
     Value: !GetAtt EKSStack.Outputs.KubeConfigPath

--- a/templates/portworx-master.template.yaml
+++ b/templates/portworx-master.template.yaml
@@ -272,7 +272,7 @@ Parameters:
   KubernetesVersion:
     Description: The Kubernetes version of the Amazon EKS cluster. (https://github.com/aws-quickstart/quickstart-amazon-eks/blob/master/templates/amazon-eks.template.yaml#L142)
     Type: String
-    Default: "1.13.0"
+    Default: "1.13"
   PortworxVersion:
     Type: String
     Default: "2.2.0"

--- a/templates/portworx-master.template.yaml
+++ b/templates/portworx-master.template.yaml
@@ -346,7 +346,7 @@ Resources:
         LightHouseVersion: !Ref LightHouseVersion
         VolumeTemplateString: !Ref VolumeTemplateString
         MetadataTemplateString: !Ref MetadataTemplateString
-        KubernetesVersion: !Ref PXKubernetesVersion
+        PXKubernetesVersion: !Ref KubernetesVersion
 Outputs:
   KubeConfigPath:
     Value: !GetAtt EKSStack.Outputs.KubeConfigPath

--- a/templates/portworx-master.template.yaml
+++ b/templates/portworx-master.template.yaml
@@ -31,7 +31,6 @@ Metadata:
     - Label:
         default: Portworx configuration
       Parameters:
-      - PXKubernetesVersion
       - PortworxVersion
       - LightHouseVersion
       - VolumeTemplateString
@@ -78,8 +77,6 @@ Metadata:
         default: Node group name
       NodeVolumeSize:
         default: Node volume size
-      PXKubernetesVersion:
-        default: Portworx version tag
       PortworxVersion:
         default: Version of Portworx X.Y.Z
       LightHouseVersion:
@@ -273,21 +270,16 @@ Parameters:
     Type: String
     Default: ''
   KubernetesVersion:
-    Description: The Kubernetes version of the Amazon EKS cluster.
+    Description: The Kubernetes version of the Amazon EKS cluster. ((https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html))
     Type: String
-    AllowedValues: [ "1.11", "1.10" ]
-    Default: "1.11"
-  PXKubernetesVersion:
-    Type: String
-    Default: "v1.11.0"
-    Description:  The tag for the Portworx container image version.
+    Default: "1.14.7"
   PortworxVersion:
     Type: String
-    Default: "2.0.1"
+    Default: "2.2.0"
     Description: The version of Portworx that is deployed by this Quick Start.
   LightHouseVersion:
     Type: String
-    Default: "2.0.1"
+    Default: "2.0.5"
     Description: The version of the Portworx Lighthouse UI.
   VolumeTemplateString:
     Type: String
@@ -350,11 +342,11 @@ Resources:
         KubeManifestLambdaArn: !GetAtt EKSStack.Outputs.KubeManifestLambdaArn
         PortworxClusterName: !Join [ "-", [ !GetAtt EKSStack.Outputs.EKSClusterName, "portworx-cluster" ] ]
         NodeGroupIAMRole: !GetAtt EKSStack.Outputs.NodeInstanceRoleName
-        PXKubernetesVersion: !Ref PXKubernetesVersion
         PortworxVersion: !Ref PortworxVersion
         LightHouseVersion: !Ref LightHouseVersion
         VolumeTemplateString: !Ref VolumeTemplateString
         MetadataTemplateString: !Ref MetadataTemplateString
+        KubernetesVersion: !Ref PXKubernetesVersion
 Outputs:
   KubeConfigPath:
     Value: !GetAtt EKSStack.Outputs.KubeConfigPath

--- a/templates/portworx-master.template.yaml
+++ b/templates/portworx-master.template.yaml
@@ -270,9 +270,9 @@ Parameters:
     Type: String
     Default: ''
   KubernetesVersion:
-    Description: The Kubernetes version of the Amazon EKS cluster. ((https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html))
+    Description: The Kubernetes version of the Amazon EKS cluster. (https://github.com/aws-quickstart/quickstart-amazon-eks/blob/master/templates/amazon-eks.template.yaml#L142)
     Type: String
-    Default: "1.14.7"
+    Default: "1.13.0"
   PortworxVersion:
     Type: String
     Default: "2.2.0"

--- a/templates/portworx.template.yaml
+++ b/templates/portworx.template.yaml
@@ -1276,7 +1276,7 @@ Resources:
       # false 
       PortworxPxEnabledNotInValue: !Ref PortworxPxEnabledNotInValue
       # Kubernetes manifest
-      Manifest:
+      Manifest: !Sub |
         apiVersion: extensions/v1beta1
         kind: DaemonSet
         metadata:

--- a/templates/portworx.template.yaml
+++ b/templates/portworx.template.yaml
@@ -1148,7 +1148,7 @@ Resources:
                 - --controllers=persistentvolume-binder,persistentvolume-expander
                 - --use-service-account-credentials=true
                 - --leader-elect-resource-lock=configmaps
-                image: !Join [ ":", [ "gcr.io/google_containers/kube-controller-manager-amd64", !Ref PXKubernetesVersion] ]
+                image: !Join [ ":v", [ "gcr.io/google_containers/kube-controller-manager-amd64", !Ref PXKubernetesVersion] ]
                 livenessProbe:
                   failureThreshold: 8
                   httpGet:

--- a/templates/portworx.template.yaml
+++ b/templates/portworx.template.yaml
@@ -673,20 +673,20 @@ Resources:
         data:
           policy.cfg: |-
             {
-            "kind": "Policy",
-            "apiVersion": "v1",
-            "extenders": [
-              {
-                "urlPrefix": "http://stork-service.kube-system:8099",
-                "apiVersion": "v1beta1",
-                "filterVerb": "filter",
-                "prioritizeVerb": "prioritize",
-                "weight": 5,
-                "enableHttps": false,
-                "nodeCacheCapable": false
-              }
-            ]
-          }
+              "kind": "Policy",
+              "apiVersion": "v1",
+              "extenders": [
+                {
+                  "urlPrefix": "http://stork-service.kube-system:8099",
+                  "apiVersion": "v1beta1",
+                  "filterVerb": "filter",
+                  "prioritizeVerb": "prioritize",
+                  "weight": 5,
+                  "enableHttps": false,
+                  "nodeCacheCapable": false
+                }
+              ]
+            }
   PXStorkDeploymentStack:
     DependsOn: PortworxNamespaceStack
     Type: "Custom::KubeManifest"

--- a/templates/portworx.template.yaml
+++ b/templates/portworx.template.yaml
@@ -306,7 +306,7 @@ Resources:
             spec:
               initContainers:
               - name: config-init
-                image: portworx/lh-config-sync:0.2
+                image: !Join [ ":", [ "portworx/lh-config-sync", !Ref LightHouseVersion ] ]
                 imagePullPolicy: Always
                 args:
                 - "init"
@@ -324,7 +324,7 @@ Resources:
                 - name: config
                   mountPath: /config/lh
               - name: config-sync
-                image: portworx/lh-config-sync:0.2
+                image: !Join [ ":", [ "portworx/lh-config-sync", !Ref LightHouseVersion ] ]
                 imagePullPolicy: Always
                 args:
                 - "sync"
@@ -348,7 +348,7 @@ Resources:
       KubeConfigKmsContext: !Ref KubeConfigKmsContext
       # Kubernetes manifest
       Manifest:
-        kind: RoleBinding
+        kind: ClusterRoleBinding
         apiVersion: rbac.authorization.k8s.io/v1
         metadata:
           name: px-lh-role-binding
@@ -358,7 +358,7 @@ Resources:
           name: px-lh-account
           namespace: kube-system
         roleRef:
-          kind: Role
+          kind: ClusterRole
           name: px-lh-role
           apiGroup: rbac.authorization.k8s.io
   PXLighthouseRoleStack:
@@ -795,54 +795,9 @@ Resources:
         metadata:
            name: stork-role
         rules:
-          - apiGroups: [""]
-            resources: ["pods", "pods/exec"]
-            verbs: ["get", "list", "delete", "create"]
-          - apiGroups: [""]
-            resources: ["persistentvolumes"]
-            verbs: ["get", "list", "watch", "create", "delete"]
-          - apiGroups: [""]
-            resources: ["persistentvolumeclaims"]
-            verbs: ["get", "list", "watch", "update"]
-          - apiGroups: ["storage.k8s.io"]
-            resources: ["storageclasses"]
-            verbs: ["get", "list", "watch"]
-          - apiGroups: [""]
-            resources: ["events"]
-            verbs: ["list", "watch", "create", "update", "patch"]
-          - apiGroups: ["stork.libopenstorage.org"]
-            resources: ["rules"]
-            verbs: ["get", "list"]
-          - apiGroups: ["stork.libopenstorage.org"]
-            resources: ["migrations", "clusterpairs"]
-            verbs: ["get", "list", "watch", "update", "patch"]
-          - apiGroups: ["apiextensions.k8s.io"]
-            resources: ["customresourcedefinitions"]
-            verbs: ["create", "get"]
-          - apiGroups: ["volumesnapshot.external-storage.k8s.io"]
-            resources: ["volumesnapshots"]
-            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-          - apiGroups: ["volumesnapshot.external-storage.k8s.io"]
-            resources: ["volumesnapshotdatas"]
-            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-          - apiGroups: [""]
-            resources: ["configmaps"]
-            verbs: ["get", "create", "update"]
-          - apiGroups: [""]
-            resources: ["services"]
-            verbs: ["get"]
-          - apiGroups: [""]
-            resources: ["nodes"]
-            verbs: ["get", "list", "watch"]
-          - apiGroups: ["*"]
-            resources: ["deployments", "deployments/extensions"]
-            verbs: ["list", "get", "watch", "patch", "update", "initialize"]
-          - apiGroups: ["*"]
-            resources: ["statefulsets", "statefulsets/extensions"]
-            verbs: ["list", "get", "watch", "patch", "update", "initialize"]
           - apiGroups: ["*"]
             resources: ["*"]
-            verbs: ["list", "get"]
+            verbs: ["*"]
   PXStorkSchedulerAccountStack:
     DependsOn: PortworxNamespaceStack
     Type: "Custom::KubeManifest"
@@ -873,7 +828,7 @@ Resources:
       # context for KMS to use when decrypting the file
       KubeConfigKmsContext: !Ref KubeConfigKmsContext
       # k8s version
-      PXKubernetesVersion: !Join [ ".", [ !Ref PXKubernetesVersion, "0"] ]
+      PXKubernetesVersion: !Ref PXKubernetesVersion
       # Kubernetes manifest
       Manifest:
         apiVersion: apps/v1beta1
@@ -903,7 +858,7 @@ Resources:
                 - --policy-configmap=stork-config
                 - --policy-configmap-namespace=kube-system
                 - --lock-object-name=stork-scheduler
-                image: !Join [ ":v", [ "gcr.io/google_containers/kube-scheduler-amd64", !Ref PXKubernetesVersion ] ]
+                image: !Join [ ":v", [ "gcr.io/google_containers/kube-scheduler-amd64", !Join [ ".", [ !Ref PXKubernetesVersion, "0"] ] ] ]
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -1113,7 +1068,7 @@ Resources:
       # context for KMS to use when decrypting the file
       KubeConfigKmsContext: !Ref KubeConfigKmsContext
       # k8s version
-      PXKubernetesVersion: !Join [ ".", [ !Ref PXKubernetesVersion, "0"] ]
+      PXKubernetesVersion: !Ref PXKubernetesVersion
       # Kubernetes manifest
       Manifest:
         apiVersion: extensions/v1beta1
@@ -1148,7 +1103,7 @@ Resources:
                 - --controllers=persistentvolume-binder,persistentvolume-expander
                 - --use-service-account-credentials=true
                 - --leader-elect-resource-lock=configmaps
-                image: !Join [ ":v", [ "gcr.io/google_containers/kube-controller-manager-amd64", !Ref PXKubernetesVersion] ]
+                image: !Join [ ":v", [ "gcr.io/google_containers/kube-controller-manager-amd64", !Join [ ".", [ !Ref PXKubernetesVersion, "0"] ] ] ]
                 livenessProbe:
                   failureThreshold: 8
                   httpGet:

--- a/templates/portworx.template.yaml
+++ b/templates/portworx.template.yaml
@@ -1273,6 +1273,8 @@ Resources:
       KubeConfigPath: !Ref KubeConfigPath
       # context for KMS to use when decrypting the file
       KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      # false 
+      PortworxPxEnabledNotInValue: !Ref PortworxPxEnabledNotInValue
       # Kubernetes manifest
       Manifest:
         apiVersion: extensions/v1beta1
@@ -1299,7 +1301,7 @@ Resources:
                       - key: px/enabled
                         operator: NotIn
                         values:
-                        - "false"
+                        - "${PortworxPxEnabledNotInValue}"
                       - key: node-role.kubernetes.io/master
                         operator: DoesNotExist
               hostNetwork: true

--- a/templates/portworx.template.yaml
+++ b/templates/portworx.template.yaml
@@ -38,7 +38,7 @@ Parameters:
     Description: The IAM NodeGroup Role for the Portworx Nodes (EKS Worker Nodes)
   PXKubernetesVersion:
     Type: String
-    Default: "v1.14.7"
+    Default: "1.13.0"
     Description:  The EKS version used scheduler container image tags
   PortworxVersion:
     Type: String

--- a/templates/portworx.template.yaml
+++ b/templates/portworx.template.yaml
@@ -903,7 +903,7 @@ Resources:
                 - --policy-configmap=stork-config
                 - --policy-configmap-namespace=kube-system
                 - --lock-object-name=stork-scheduler
-                image: !Join [ ":", [ "gcr.io/google_containers/kube-scheduler-amd64", !Ref PXKubernetesVersion ] ]
+                image: !Join [ ":v", [ "gcr.io/google_containers/kube-scheduler-amd64", !Ref PXKubernetesVersion ] ]
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/templates/portworx.template.yaml
+++ b/templates/portworx.template.yaml
@@ -38,7 +38,7 @@ Parameters:
     Description: The IAM NodeGroup Role for the Portworx Nodes (EKS Worker Nodes)
   PXKubernetesVersion:
     Type: String
-    Default: "1.13.0"
+    Default: "1.13"
     Description:  The EKS version used scheduler container image tags
   PortworxVersion:
     Type: String
@@ -873,7 +873,7 @@ Resources:
       # context for KMS to use when decrypting the file
       KubeConfigKmsContext: !Ref KubeConfigKmsContext
       # k8s version
-      PXKubernetesVersion: !Ref PXKubernetesVersion
+      PXKubernetesVersion: !Join [ ".", [ !Ref PXKubernetesVersion, "0"] ]
       # Kubernetes manifest
       Manifest:
         apiVersion: apps/v1beta1
@@ -1113,7 +1113,7 @@ Resources:
       # context for KMS to use when decrypting the file
       KubeConfigKmsContext: !Ref KubeConfigKmsContext
       # k8s version
-      PXKubernetesVersion: !Ref PXKubernetesVersion
+      PXKubernetesVersion: !Join [ ".", [ !Ref PXKubernetesVersion, "0"] ]
       # Kubernetes manifest
       Manifest:
         apiVersion: extensions/v1beta1

--- a/templates/portworx.template.yaml
+++ b/templates/portworx.template.yaml
@@ -10,6 +10,7 @@ Metadata:
       - PortworxVersion
       - LightHouseVersion
       - VolumeTemplateString
+      - MetadataTemplateString
     ParameterLabels:
       PXKubernetesVersion:
         default: The EKS version used scheduler container image tags
@@ -19,6 +20,8 @@ Metadata:
         default: Version of Lighthouse X.Y.Z
       VolumeTemplateString:
         default: The template string (https://docs.portworx.com/cloud-references/auto-disk-provisioning/aws/)
+      MetadataTemplateString:
+        default: The template string for metadata device for internal KVDB
 Parameters:
   KubeManifestLambdaArn:
     Type: String
@@ -35,24 +38,28 @@ Parameters:
     Description: The IAM NodeGroup Role for the Portworx Nodes (EKS Worker Nodes)
   PXKubernetesVersion:
     Type: String
-    Default: "v1.11.0"
+    Default: "v1.14.7"
     Description:  The EKS version used scheduler container image tags
   PortworxVersion:
     Type: String
-    Default: "2.0.1"
+    Default: "2.2.0"
     Description: Version of portworx X.Y.Z
   LightHouseVersion:
     Type: String
-    Default: "2.0.1"
+    Default: "2.0.5"
     Description: Version of Lighthouse X.Y.Z
   VolumeTemplateString:
+    Type: String
+    Default: "type=gp2,size=100"
+    Description: The template string (https://docs.portworx.com/cloud-references/auto-disk-provisioning/aws/)
+  MetadataTemplateString:
     Type: String
     Default: "type=gp2,size=100"
     Description: The template string (https://docs.portworx.com/cloud-references/auto-disk-provisioning/aws/)
   PortworxPxEnabledNotInValue:
     Type: String
     Default: "false"
-    Description: Font deploy Portworx deploy if px/enabled equal
+    Description: Dont deploy Portworx deploy if px/enabled equal
 Resources:
   PortworxNamespaceStack:
     Type: "Custom::KubeManifest"
@@ -127,9 +134,12 @@ Resources:
                   args:
                     ["-b", "-c", "${PortworxClusterName}", 
                      "-s", "${VolumeTemplateString}", 
+                     "-metadata", "${MetadataTemplateString}", 
                      "-secret_type", "k8s", 
                      "-x", "kubernetes"]
                   env:
+                    - name: "AUTO_NODE_RECOVERY_TIMEOUT_IN_SECS"
+                      value: "1500"
                     - name: "PX_TEMPLATE_VERSION"
                       value: "v4"
                     
@@ -150,20 +160,26 @@ Resources:
                   securityContext:
                     privileged: true
                   volumeMounts:
+                    - name: diagsdump
+                      mountPath: /var/cores
                     - name: dockersock
                       mountPath: /var/run/docker.sock
                     - name: containerdsock
                       mountPath: /run/containerd
+                    - name: criosock
+                      mountPath: /var/run/crio
+                    - name: crioconf
+                      mountPath: /etc/crictl.yaml
                     - name: etcpwx
                       mountPath: /etc/pwx
+                    - name: dev
+                      mountPath: /dev
                     - name: optpwx
                       mountPath: /opt/pwx
-                    - name: hostprocmount
+                    - name: procmount
                       mountPath: /host_proc
                     - name: sysdmount
                       mountPath: /etc/systemd/system
-                    - name: diagsdump
-                      mountPath: /var/cores
                     - name: journalmount1
                       mountPath: /var/run/log
                       readOnly: true
@@ -175,27 +191,37 @@ Resources:
               restartPolicy: Always
               serviceAccountName: px-account
               volumes:
+                - name: diagsdump
+                  hostPath:
+                    path: /var/cores
                 - name: dockersock
                   hostPath:
                     path: /var/run/docker.sock
                 - name: containerdsock
                   hostPath:
                     path: /run/containerd
+                - name: criosock
+                  hostPath:
+                    path: /var/run/crio
+                - name: crioconf
+                  hostPath:
+                    path: /etc/crictl.yaml
+                    type: FileOrCreate
                 - name: etcpwx
                   hostPath:
                     path: /etc/pwx
+                - name: dev
+                  hostPath:
+                    path: /dev
                 - name: optpwx
                   hostPath:
                     path: /opt/pwx
-                - name: hostprocmount
+                - name: procmount
                   hostPath:
-                    path: /proc/
+                    path: /proc
                 - name: sysdmount
                   hostPath:
                     path: /etc/systemd/system
-                - name: diagsdump
-                  hostPath:
-                    path: /var/cores
                 - name: journalmount1
                   hostPath:
                     path: /var/run/log
@@ -348,15 +374,43 @@ Resources:
       KubeConfigKmsContext: !Ref KubeConfigKmsContext
       # Kubernetes manifest
       Manifest:
-        kind: Role
+        kind: ClusterRole
         apiVersion: rbac.authorization.k8s.io/v1
         metadata:
-           name: px-lh-role
-           namespace: kube-system
+          name: px-lh-role
+          namespace: kube-system
         rules:
-        - apiGroups: [""]
-          resources: ["configmaps"]
-          verbs: ["get", "create", "update"]
+          - apiGroups: [""]
+            resources: ["pods"]
+            verbs: ["list", "get"]
+          - apiGroups:
+                - extensions
+                - apps
+            resources:
+                - deployments
+            verbs: ["get", "list"]
+          - apiGroups: [""]
+            resources: ["secrets"]
+            verbs: ["get", "create", "update"]
+          - apiGroups: [""]
+            resources: ["configmaps"]
+            verbs: ["get", "create", "update"]
+          - apiGroups: [""]
+            resources: ["nodes"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: [""]
+            resources: ["services"]
+            verbs: ["create", "get", "list", "watch"]
+          - apiGroups: ["stork.libopenstorage.org"]
+            resources: ["clusterpairs","migrations","groupvolumesnapshots"]
+            verbs: ["get", "list", "create", "update", "delete"]
+          - apiGroups: ["monitoring.coreos.com"]
+            resources:
+              - alertmanagers
+              - prometheuses
+              - prometheuses/finalizers
+              - servicemonitors
+            verbs: ["*"]
   PXLighthouseServiceStack:
     DependsOn: PortworxNamespaceStack
     Type: "Custom::KubeManifest"
@@ -378,14 +432,12 @@ Resources:
           labels:
             tier: px-web-console
         spec:
-          type: NodePort
+          type: LoadBalancer
           ports:
             - port: 80
               name: http
-              nodePort: 32678
             - port: 443
               name: https
-              nodePort: 32679
           selector:
             tier: px-web-console
   PXNodeGetPutListRoleStack:
@@ -407,11 +459,14 @@ Resources:
            name: node-get-put-list-role
         rules:
         - apiGroups: [""]
+          resources: ["secrets"]
+          verbs: ["get", "list"]
+        - apiGroups: [""]
           resources: ["nodes"]
           verbs: ["watch", "get", "update", "list"]
         - apiGroups: [""]
           resources: ["pods"]
-          verbs: ["delete", "get", "list"]
+          verbs: ["delete", "get", "list", "watch", "update"]
         - apiGroups: [""]
           resources: ["persistentvolumeclaims", "persistentvolumes"]
           verbs: ["get", "list"]
@@ -422,6 +477,12 @@ Resources:
           resources: ["podsecuritypolicies"]
           resourceNames: ["privileged"]
           verbs: ["use"]
+        - apiGroups: ["portworx.io"]
+          resources: ["volumeplacementstrategies"]
+          verbs: ["get", "list"]
+        - apiGroups: ["stork.libopenstorage.org"]
+          resources: ["backuplocations"]
+          verbs: ["get", "list"]
   PXNodeRoleBindingStack:
     DependsOn: PortworxNamespaceStack
     Type: "Custom::KubeManifest"
@@ -495,6 +556,43 @@ Resources:
         - apiGroups: [""]
           resources: ["secrets"]
           verbs: ["get", "list", "create", "update", "patch"]
+  PXApiStack:
+    DependsOn: PortworxNamespaceStack
+    Type: "Custom::KubeManifest"
+    Version: '1.0'
+    Properties:
+      # The lambda function that executes the manifest against the cluster. This is created in one of the parent stacks
+      ServiceToken: !Ref KubeManifestLambdaArn
+      # S3 path to the encrypted config file eg. s3://my-bucket/kube/config.encrypted
+      KubeConfigPath: !Ref KubeConfigPath
+      # context for KMS to use when decrypting the file
+      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      # Kubernetes manifest
+      Manifest:
+        kind: Service
+        apiVersion: v1
+        metadata:
+          name: portworx-api
+          namespace: kube-system
+          labels:
+            name: portworx-api
+        spec:
+          selector:
+            name: portworx-api
+          type: NodePort
+          ports:
+            - name: px-api
+              protocol: TCP
+              port: 9001
+              targetPort: 9001
+            - name: px-sdk
+              protocol: TCP
+              port: 9020
+              targetPort: 9020
+            - name: px-rest-gateway
+              protocol: TCP
+              port: 9021
+              targetPort: 9021
   PXServiceStack:
     DependsOn: PortworxNamespaceStack
     Type: "Custom::KubeManifest"
@@ -518,11 +616,24 @@ Resources:
         spec:
           selector:
             name: portworx
+          type: NodePort
           ports:
-            - protocol: TCP
-              name: px-api
+            - name: px-api
+              protocol: TCP
               port: 9001
               targetPort: 9001
+            - name: px-kvdb
+              protocol: TCP
+              port: 9019
+              targetPort: 9019
+            - name: px-sdk
+              protocol: TCP
+              port: 9020
+              targetPort: 9020
+            - name: px-rest-gateway
+              protocol: TCP
+              port: 9021
+              targetPort: 9021
   PXStorkAccountStack:
     DependsOn: PortworxNamespaceStack
     Type: "Custom::KubeManifest"
@@ -562,20 +673,20 @@ Resources:
         data:
           policy.cfg: |-
             {
-              "kind": "Policy",
-              "apiVersion": "v1",
-              "extenders": [
-                {
-                  "urlPrefix": "http://stork-service.kube-system:8099",
-                  "apiVersion": "v1beta1",
-                  "filterVerb": "filter",
-                  "prioritizeVerb": "prioritize",
-                  "weight": 5,
-                  "enableHttps": false,
-                  "nodeCacheCapable": false
-                }
-              ]
-            }
+            "kind": "Policy",
+            "apiVersion": "v1",
+            "extenders": [
+              {
+                "urlPrefix": "http://stork-service.kube-system:8099",
+                "apiVersion": "v1beta1",
+                "filterVerb": "filter",
+                "prioritizeVerb": "prioritize",
+                "weight": 5,
+                "enableHttps": false,
+                "nodeCacheCapable": false
+              }
+            ]
+          }
   PXStorkDeploymentStack:
     DependsOn: PortworxNamespaceStack
     Type: "Custom::KubeManifest"
@@ -599,12 +710,12 @@ Resources:
           name: stork
           namespace: kube-system
         spec:
-          replicas: 3
           strategy:
             rollingUpdate:
               maxSurge: 1
               maxUnavailable: 1
             type: RollingUpdate
+          replicas: 3
           template:
             metadata:
               annotations:
@@ -621,7 +732,10 @@ Resources:
                 - --leader-elect=true
                 - --health-monitor-interval=120
                 imagePullPolicy: Always
-                image: openstorage/stork:1.3.0-beta1
+                image: openstorage/stork:2.3.1
+                env:
+                - name: "PX_SERVICE_NAME"
+                  value: "portworx-api"
                 resources:
                   requests:
                     cpu: '0.1'
@@ -860,16 +974,13 @@ Resources:
         rules:
           - apiGroups: [""]
             resources: ["endpoints"]
-            verbs: ["get", "update"]
+            verbs: ["get", "create", "update"]
           - apiGroups: [""]
             resources: ["configmaps"]
             verbs: ["get"]
           - apiGroups: [""]
             resources: ["events"]
             verbs: ["create", "patch", "update"]
-          - apiGroups: [""]
-            resources: ["endpoints"]
-            verbs: ["create"]
           - apiGroups: [""]
             resourceNames: ["kube-scheduler"]
             resources: ["endpoints"]
@@ -889,7 +1000,7 @@ Resources:
           - apiGroups: [""]
             resources: ["replicationcontrollers", "services"]
             verbs: ["get", "list", "watch"]
-          - apiGroups: ["app", "extensions"]
+          - apiGroups: ["apps", "extensions"]
             resources: ["replicasets"]
             verbs: ["get", "list", "watch"]
           - apiGroups: ["apps"]
@@ -1107,19 +1218,104 @@ Resources:
           verbs: ["get", "list"]
         - apiGroups: [""]
           resources: ["nodes"]
-          verbs: ["get", "list"]
+          verbs: ["get", "list", "watch"]
         - apiGroups: [""]
           resources: ["events"]
-          verbs: ["watch"]
-        - apiGroups: [""]
-          resources: ["events"]
-          verbs: ["create", "patch", "update"]
+          verbs: ["watch", "create", "patch", "update"]
         - apiGroups: [""]
           resources: ["serviceaccounts"]
           verbs: ["get", "create"]
         - apiGroups: [""]
           resources: ["configmaps"]
           verbs: ["get", "create", "update"]
+  PXVolumePlacementStrategiesStack:
+    DependsOn: PortworxNamespaceStack
+    Type: "Custom::KubeManifest"
+    Version: '1.0'
+    Properties:
+      # The lambda function that executes the manifest against the cluster. This is created in one of the parent stacks
+      ServiceToken: !Ref KubeManifestLambdaArn
+      # S3 path to the encrypted config file eg. s3://my-bucket/kube/config.encrypted
+      KubeConfigPath: !Ref KubeConfigPath
+      # context for KMS to use when decrypting the file
+      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      # Kubernetes manifest
+      Manifest:
+        apiVersion: apiextensions.k8s.io/v1beta1
+        kind: CustomResourceDefinition
+        metadata:
+          name: volumeplacementstrategies.portworx.io
+        spec:
+          group: portworx.io
+          versions:
+            - name: v1beta2
+              served: true
+              storage: true
+            - name: v1beta1
+              served: false
+              storage: false
+          scope: Cluster
+          names:
+            plural: volumeplacementstrategies
+            singular: volumeplacementstrategy
+            kind: VolumePlacementStrategy
+            shortNames:
+            - vps
+            - vp
+  PXApiDSStack:
+    DependsOn: PortworxNamespaceStack
+    Type: "Custom::KubeManifest"
+    Version: '1.0'
+    Properties:
+      # The lambda function that executes the manifest against the cluster. This is created in one of the parent stacks
+      ServiceToken: !Ref KubeManifestLambdaArn
+      # S3 path to the encrypted config file eg. s3://my-bucket/kube/config.encrypted
+      KubeConfigPath: !Ref KubeConfigPath
+      # context for KMS to use when decrypting the file
+      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      # Kubernetes manifest
+      Manifest:
+        apiVersion: extensions/v1beta1
+        kind: DaemonSet
+        metadata:
+          name: portworx-api
+          namespace: kube-system
+        spec:
+          minReadySeconds: 0
+          updateStrategy:
+            type: RollingUpdate
+            rollingUpdate:
+              maxUnavailable: 100%
+          template:
+            metadata:
+              labels:
+                name: portworx-api
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: px/enabled
+                        operator: NotIn
+                        values:
+                        - "false"
+                      - key: node-role.kubernetes.io/master
+                        operator: DoesNotExist
+              hostNetwork: true
+              hostPID: false
+              containers:
+                - name: portworx-api
+                  image: k8s.gcr.io/pause:3.1
+                  imagePullPolicy: Always
+                  readinessProbe:
+                    periodSeconds: 10
+                    httpGet:
+                      host: 127.0.0.1
+                      path: /status
+                      port: 9001
+              restartPolicy: Always
+              serviceAccountName: px-account
   PXNodePolicyStack:
     Type: AWS::IAM::Policy
     Properties:


### PR DESCRIPTION
Fixes #6 and general update to latest PX version.

- Updates base installation to uses newest Portworx 2.2.0
- Updates default parameters including latest EKS 1.13.0 from aws eks quickstart.
- Updates Services to use LoadBalancer type so Lighthouse and Prometheus can be accessed easily.
- Adds Portworx Monitoring Stack to examples
- Updates README with Limitations.
- Reduces Parameters needed by re-using EKS version to pass to Kubernetes versions needed by Portworx.
- Updates Manifests for Portworx.
- Adds Metadata EBS devices for internal KVDB stability


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
